### PR TITLE
Matomo Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,6 +57,10 @@ plugins:
   - jemoji
   - jekyll-include-cache
 
+# Matomo Analaytics
+analytics:
+  provider: "custom"
+
 footer:
   links:
     - label: "Twitter"

--- a/_includes/analytics-providers/custom.html
+++ b/_includes/analytics-providers/custom.html
@@ -1,0 +1,19 @@
+<head>
+
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//matomo.digidemlab.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '29']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
+</head>


### PR DESCRIPTION
Changes to add matomo analytics to the website, following instructions [here](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#seo-social-sharing-and-analytics-settings).